### PR TITLE
run klum process as non-root in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ ARG COMMIT
 
 RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.Version=$VERSION -X main.GitCommit=$COMMIT"
+RUN adduser --uid 1000 --disabled-password klum-user
 
 FROM scratch
+COPY --from=build /etc/passwd /etc/passwd
 COPY --from=build /app/klum /klum
+USER klum-user
 CMD ["/klum"]


### PR DESCRIPTION
Hi @jadolg,

it is common best security practice to run the application process inside the container as non-root.
I made the required changes to the Dockerfile and tested successfully in our cluster with following kubernetes securityContext: 

```yaml
securityContext:
  capabilities:
    drop:
    - ALL
  readOnlyRootFilesystem: true
  runAsNonRoot: true
  runAsUser: 1000
```

Cheers Karsten
