### PR TITLE
Better caching in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,29 @@
-./.dapper
-./.cache
-./dist
+# Temp files
+.cache
+.dist
+
+# Git
+.git
+**/*.gitignore
+**/*.gitattributes
+
+# CI
+.dapper
+.github
+.golangci.json
+scripts
+
+# Docker
+Dockerfile
+
+# Docs
+**/*.md
+
+# OS
+**/.DS_Store
+**/Thumbs.db
+
+# Editors
+**/.vscode
+**/.idea
+**/*.swp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
+        cache: true
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,3 +31,5 @@ jobs:
           build-args: |
             VERSION=${{ github.ref_name }}
             COMMIT=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM golang:1.20 as build
+FROM golang:1.20-alpine as build
 
-ADD . /app
+RUN adduser --uid 1000 --disabled-password klum-user
+
 WORKDIR /app
+
+COPY go.mod go.sum .
+RUN go mod download
+
+COPY . .
 
 ARG VERSION
 ARG COMMIT
-
-RUN go mod tidy
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.Version=$VERSION -X main.GitCommit=$COMMIT"
-RUN adduser --uid 1000 --disabled-password klum-user
 
 FROM scratch
 COPY --from=build /etc/passwd /etc/passwd


### PR DESCRIPTION
- Use smaller base image. Using CGOENABLED=0 anyway, so doesn't matter much if we're building on glibc or musl
- Improved Docker layer caching. Caches go.mod separately, and ignores changes to Git, Dockerfile, etc in Docker caching
- Added caching to GitHub Actions

Closes #8
