### PR TITLE
Add certificates packaged by alpine to the end image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN adduser --uid 1000 --disabled-password klum-user
 
 WORKDIR /app
 
-COPY go.mod go.sum .
+COPY go.mod go.sum /app/
 RUN go mod download
 
 COPY . .
@@ -15,6 +15,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.Version=$VERSION -X main
 
 FROM scratch
 COPY --from=build /etc/passwd /etc/passwd
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/klum /klum
 USER klum-user
 CMD ["/klum"]


### PR DESCRIPTION
`scratch` doesn't ship with any certificates so we need to steal the ones packaged with alpine so we can talk to GitHub.
The error message looks like this:
`tls: failed to verify certificate: x509: certificate signed by unknown authority`