### PR TITLE
Added namespace to contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ spec:
 ```
 
 ### Use a different context name
+
 You might want to use a different context name in the kubeconfig.  You can do this
 by setting the `context` field in the User spec. The cluster name will still be the
 context name passed to klum.
+
 ```yaml
 kind: User
 apiVersion: klum.cattle.io/v1alpha1
@@ -84,6 +86,23 @@ spec:
   context: my-context
 ```
 
+### Use a different context namespace
+
+Klum will by default set the namespace field of the kubeconfig context to
+the first namespace it finds in `User`'s `spec.roles[].namespace` field,
+or fallback to namespace `default` if the user is not assigned to any namespace.
+
+You can override the kubeconfig context's namespace by setting
+the `contextNamespace` field in the User spec.
+
+```yaml
+kind: User
+apiVersion: klum.cattle.io/v1alpha1
+metadata:
+  name: darren
+spec:
+  contextNamespace: my-namespace
+```
 
 ### Upload kubeconfig to GitHub secrets
 

--- a/pkg/apis/klum.cattle.io/v1alpha1/types.go
+++ b/pkg/apis/klum.cattle.io/v1alpha1/types.go
@@ -25,10 +25,11 @@ type User struct {
 }
 
 type UserSpec struct {
-	Enabled      *bool           `json:"enabled,omitempty"`
-	ClusterRoles []string        `json:"clusterRoles,omitempty"`
-	Roles        []NamespaceRole `json:"roles,omitempty"`
-	Context      string          `json:"context,omitempty"`
+	Enabled          *bool           `json:"enabled,omitempty"`
+	ClusterRoles     []string        `json:"clusterRoles,omitempty"`
+	Roles            []NamespaceRole `json:"roles,omitempty"`
+	Context          string          `json:"context,omitempty"`
+	ContextNamespace string          `json:"contextNamespace,omitempty"`
 }
 
 type UserStatus struct {
@@ -100,6 +101,8 @@ type Context struct {
 	Cluster string `json:"cluster"`
 	// AuthInfo is the name of the authInfo for this context
 	AuthInfo string `json:"user"`
+	// Namespace is the name of the current namespace for this context
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // NamedContext relates nicknames to context information


### PR DESCRIPTION
Added `namespace` field to the kubeconfig's context.

This defaults to the same `namespace` value of the first `spec.roles`, or fallbacks to targeting the `default` namespace.
